### PR TITLE
Remove fin year entries that have no corresponding asset register tables

### DIFF
--- a/scripts/v6/prime/06-asset-admin.sql
+++ b/scripts/v6/prime/06-asset-admin.sql
@@ -5,5 +5,3 @@ INSERT INTO AssetRefCounter (counter_name, counter_prev_id, counter_current_id, 
 
 -- AssetFinYear inserts
 INSERT INTO AssetFinYear (FinYear, Period) VALUES(2015,1);
-INSERT INTO AssetFinYear (FinYear, Period) VALUES(2016,1);
-INSERT INTO AssetFinYear (FinYear, Period) VALUES(2017,1);


### PR DESCRIPTION
Those entries leaves the prepped db in an invalid state: having an open financial year with no corresponding tables...